### PR TITLE
build: optimize binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,6 @@ dependencies = [
  "flate2",
  "reqwest",
  "serde",
- "serde_json",
  "tar",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ clap = { version = "4.5.54", features = ["derive"] }
 flate2 = "1.1.8"
 reqwest = { version = "0.13.1", features = ["json", "blocking"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
 tar = "0.4.44"
 zip = "7.1.0"
 


### PR DESCRIPTION
This pull request introduces optimizations to the release build configuration in `Cargo.toml` to improve the performance and reduce the binary size of the application.

Release build optimizations:

* Enabled Link Time Optimization (`lto = true`) to allow for more aggressive compiler optimizations.
* Set `opt-level = "s"` to optimize for binary size, making the final executable smaller.
* Reduced `codegen-units` to 1 to improve optimization at the cost of longer compile times.
* Enabled symbol stripping (`strip = "symbols"`) to further reduce the binary size by removing debug symbols.