### PR TITLE
refactor(asset): Separate pure matching from interactive selection

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -226,7 +226,14 @@ pub fn select_asset(
         if !io::stdin().is_terminal() {
             bail!("Cannot select asset in non-terminal environment");
         }
-        return interactive_select(assets, &[], os, &Some(arch.to_string()), arch, "Select an asset:");
+        return interactive_select(
+            assets,
+            &[],
+            os,
+            &Some(arch.to_string()),
+            arch,
+            "Select an asset:",
+        );
     }
 
     match find_asset(assets, os, arch, exclude) {
@@ -248,9 +255,7 @@ pub fn select_asset(
         }
         Selection::None => {
             if !io::stdin().is_terminal() {
-                bail!(
-                    "No matching asset found for {os}-{arch}. Select from available assets:"
-                );
+                bail!("No matching asset found for {os}-{arch}. Select from available assets:");
             }
             let mut all: Vec<&Asset> = assets.iter().collect();
             sort_by_score(&mut all, os, arch);
@@ -405,7 +410,10 @@ mod tests {
         }];
 
         let result = find_asset(&assets, "win32", "x86_64", None);
-        assert!(matches!(result, Selection::None), "darwin assets should NOT match win32");
+        assert!(
+            matches!(result, Selection::None),
+            "darwin assets should NOT match win32"
+        );
     }
 
     #[test]
@@ -417,7 +425,10 @@ mod tests {
         }];
 
         let result = find_asset(&assets, "win64", "x86_64", None);
-        assert!(matches!(result, Selection::None), "darwin assets should NOT match win64");
+        assert!(
+            matches!(result, Selection::None),
+            "darwin assets should NOT match win64"
+        );
     }
 
     #[test]
@@ -581,7 +592,10 @@ mod tests {
         ];
 
         let result = find_asset(&assets, "windows", "x86_64", None);
-        assert!(matches!(result, Selection::None), "darwin assets should NOT match Windows");
+        assert!(
+            matches!(result, Selection::None),
+            "darwin assets should NOT match Windows"
+        );
     }
 
     #[test]

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -222,15 +222,21 @@ pub fn select_asset(
     force_select: bool,
     exclude: Option<&str>,
 ) -> Result<Asset> {
+    let blacklist: Vec<String> = exclude.map_or_else(Vec::new, |s| {
+        s.split(',').map(|w| w.trim().to_lowercase()).collect()
+    });
+    let (normalized_os, inferred_arch) = normalize_platform_identifier(os);
+    let effective_arch = inferred_arch.or(Some(arch.to_string()));
+
     if force_select {
         if !io::stdin().is_terminal() {
             bail!("Cannot select asset in non-terminal environment");
         }
         return interactive_select(
             assets,
-            &[],
-            os,
-            &Some(arch.to_string()),
+            &blacklist,
+            &normalized_os,
+            &effective_arch,
             arch,
             "Select an asset:",
         );
@@ -242,25 +248,33 @@ pub fn select_asset(
             if !io::stdin().is_terminal() {
                 bail!(
                     "Multiple assets found for {}-{}. Refine your filters to select a single asset or run in an interactive terminal.",
-                    os,
-                    arch
+                    normalized_os,
+                    effective_arch.as_deref().unwrap_or(arch)
                 );
             }
             let mut sorted = matches.iter().collect::<Vec<_>>();
-            sort_by_score(&mut sorted, os, arch);
-            println!("Multiple assets found. Select one:");
-            show_all_assets(&sorted, os, arch);
+            let arch_ref = effective_arch.as_deref().unwrap_or(arch);
+            sort_by_score(&mut sorted, &normalized_os, arch_ref);
+            println!("Multiple assets found for {normalized_os}-{arch_ref}. Select one:");
+            show_all_assets(&sorted, &normalized_os, arch_ref);
             let selected = collect_selection(&sorted)?;
             Ok(selected.clone())
         }
         Selection::None => {
             if !io::stdin().is_terminal() {
-                bail!("No matching asset found for {os}-{arch}. Select from available assets:");
+                bail!(
+                    "No matching asset found for {}-{}. Run in an interactive terminal to select from available assets, or refine your filters.",
+                    normalized_os,
+                    effective_arch.as_deref().unwrap_or(arch)
+                );
             }
             let mut all: Vec<&Asset> = assets.iter().collect();
-            sort_by_score(&mut all, os, arch);
-            println!("No matching asset found for {os}-{arch}. Select from available assets:");
-            show_all_assets(&all, os, arch);
+            let arch_ref = effective_arch.as_deref().unwrap_or(arch);
+            sort_by_score(&mut all, &normalized_os, arch_ref);
+            println!(
+                "No matching asset found for {normalized_os}-{arch_ref}. Select from available assets:"
+            );
+            show_all_assets(&all, &normalized_os, arch_ref);
             let selected = collect_selection(&all)?;
             Ok(selected.clone())
         }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -187,13 +187,13 @@ fn collect_selection<'a>(assets: &'a [&'a Asset]) -> Result<&'a Asset> {
     }
 }
 
-pub fn select_asset(
-    assets: &[Asset],
-    os: &str,
-    arch: &str,
-    force_select: bool,
-    exclude: Option<&str>,
-) -> Result<Asset> {
+pub enum Selection {
+    Exact(Asset),
+    Multiple(Vec<Asset>),
+    None,
+}
+
+pub fn find_asset(assets: &[Asset], os: &str, arch: &str, exclude: Option<&str>) -> Selection {
     let blacklist: Vec<String> = exclude.map_or_else(Vec::new, |s| {
         s.split(',').map(|w| w.trim().to_lowercase()).collect()
     });
@@ -208,57 +208,58 @@ pub fn select_asset(
 
     let matches = collect_matches(assets, &blacklist, &normalized_os, &effective_arch);
 
-    if force_select {
-        handle_force_select(assets, &blacklist, &normalized_os, &effective_arch, arch)
-    } else {
-        match matches.len() {
-            0 => handle_no_matches(
-                assets,
-                &blacklist,
-                &normalized_os,
-                &effective_arch,
-                arch,
-                os,
-            ),
-            1 => Ok(matches[0].clone()),
-            _ => handle_multiple_matches(matches, &normalized_os, &effective_arch, arch, os),
-        }
+    match matches.len() {
+        0 => Selection::None,
+        1 => Selection::Exact(matches[0].clone()),
+        _ => Selection::Multiple(matches.into_iter().cloned().collect()),
     }
 }
 
-fn handle_force_select(
+pub fn select_asset(
     assets: &[Asset],
-    blacklist: &[String],
-    normalized_os: &str,
-    effective_arch: &Option<String>,
-    arch: &str,
-) -> Result<Asset> {
-    interactive_select(
-        assets,
-        blacklist,
-        normalized_os,
-        effective_arch,
-        arch,
-        "Select an asset:",
-    )
-}
-
-fn handle_no_matches(
-    assets: &[Asset],
-    blacklist: &[String],
-    normalized_os: &str,
-    effective_arch: &Option<String>,
-    arch: &str,
     os: &str,
+    arch: &str,
+    force_select: bool,
+    exclude: Option<&str>,
 ) -> Result<Asset> {
-    interactive_select(
-        assets,
-        blacklist,
-        normalized_os,
-        effective_arch,
-        arch,
-        &format!("No matching asset found for {os}-{arch}. Select from available assets:"),
-    )
+    if force_select {
+        if !io::stdin().is_terminal() {
+            bail!("Cannot select asset in non-terminal environment");
+        }
+        return interactive_select(assets, &[], os, &Some(arch.to_string()), arch, "Select an asset:");
+    }
+
+    match find_asset(assets, os, arch, exclude) {
+        Selection::Exact(asset) => Ok(asset),
+        Selection::Multiple(matches) => {
+            if !io::stdin().is_terminal() {
+                bail!(
+                    "Multiple assets found for {}-{}. Refine your filters to select a single asset or run in an interactive terminal.",
+                    os,
+                    arch
+                );
+            }
+            let mut sorted = matches.iter().collect::<Vec<_>>();
+            sort_by_score(&mut sorted, os, arch);
+            println!("Multiple assets found. Select one:");
+            show_all_assets(&sorted, os, arch);
+            let selected = collect_selection(&sorted)?;
+            Ok(selected.clone())
+        }
+        Selection::None => {
+            if !io::stdin().is_terminal() {
+                bail!(
+                    "No matching asset found for {os}-{arch}. Select from available assets:"
+                );
+            }
+            let mut all: Vec<&Asset> = assets.iter().collect();
+            sort_by_score(&mut all, os, arch);
+            println!("No matching asset found for {os}-{arch}. Select from available assets:");
+            show_all_assets(&all, os, arch);
+            let selected = collect_selection(&all)?;
+            Ok(selected.clone())
+        }
+    }
 }
 
 fn interactive_select(
@@ -291,36 +292,6 @@ fn interactive_select(
         effective_arch.as_deref().unwrap_or(arch),
     );
     let selected = collect_selection(&all_assets)?;
-    Ok(selected.clone())
-}
-
-fn handle_multiple_matches(
-    matches: Vec<&Asset>,
-    normalized_os: &str,
-    effective_arch: &Option<String>,
-    arch: &str,
-    os: &str,
-) -> Result<Asset> {
-    if !io::stdin().is_terminal() {
-        bail!(
-            "Multiple assets found for {}-{}. Refine your filters to select a single asset or run in an interactive terminal.",
-            os,
-            arch
-        );
-    }
-    let mut sorted_matches = matches.clone();
-    sort_by_score(
-        &mut sorted_matches,
-        normalized_os,
-        effective_arch.as_deref().unwrap_or(arch),
-    );
-    println!("Multiple assets found. Select one:");
-    show_all_assets(
-        &sorted_matches,
-        normalized_os,
-        effective_arch.as_deref().unwrap_or(arch),
-    );
-    let selected = collect_selection(&sorted_matches)?;
     Ok(selected.clone())
 }
 
@@ -433,8 +404,8 @@ mod tests {
             size: 1024,
         }];
 
-        let result = select_asset(&assets, "win32", "x86_64", false, None);
-        assert!(result.is_err(), "darwin assets should NOT match win32");
+        let result = find_asset(&assets, "win32", "x86_64", None);
+        assert!(matches!(result, Selection::None), "darwin assets should NOT match win32");
     }
 
     #[test]
@@ -445,8 +416,8 @@ mod tests {
             size: 1024,
         }];
 
-        let result = select_asset(&assets, "win64", "x86_64", false, None);
-        assert!(result.is_err(), "darwin assets should NOT match win64");
+        let result = find_asset(&assets, "win64", "x86_64", None);
+        assert!(matches!(result, Selection::None), "darwin assets should NOT match win64");
     }
 
     #[test]
@@ -544,8 +515,11 @@ mod tests {
             },
         ];
 
-        let result = select_asset(&assets, "linux", "x86_64", false, Some("gnu")).unwrap();
-        assert_eq!(result.name, "app-x86_64-linux-musl.tar.gz");
+        let result = find_asset(&assets, "linux", "x86_64", Some("gnu"));
+        match result {
+            Selection::Exact(asset) => assert_eq!(asset.name, "app-x86_64-linux-musl.tar.gz"),
+            _ => panic!("Expected Selection::Exact"),
+        }
     }
 
     #[test]
@@ -568,12 +542,8 @@ mod tests {
             },
         ];
 
-        // In non-terminal environment, multiple matches should error
-        let result = select_asset(&assets, "linux", "x86_64", false, None);
-        assert!(
-            result.is_err(),
-            "Multiple matches should error in non-terminal environment"
-        );
+        let result = find_asset(&assets, "linux", "x86_64", None);
+        assert!(matches!(result, Selection::Multiple(_)));
     }
 
     #[test]
@@ -591,20 +561,8 @@ mod tests {
             },
         ];
 
-        // In non-terminal environment, multiple matches should error
-        let result = select_asset(&assets, "linux", "x86_64", false, None);
-        assert!(
-            result.is_err(),
-            "Multiple matches should error in non-terminal environment"
-        );
-
-        if let Err(e) = result {
-            let error_msg = e.to_string().to_lowercase();
-            assert!(
-                error_msg.contains("multiple") || error_msg.contains("select"),
-                "Error message should mention multiple assets and suggest --select flag"
-            );
-        }
+        let result = find_asset(&assets, "linux", "x86_64", None);
+        assert!(matches!(result, Selection::Multiple(_)));
     }
 
     #[test]
@@ -622,8 +580,8 @@ mod tests {
             },
         ];
 
-        let result = select_asset(&assets, "windows", "x86_64", false, None);
-        assert!(result.is_err(), "darwin assets should NOT match Windows");
+        let result = find_asset(&assets, "windows", "x86_64", None);
+        assert!(matches!(result, Selection::None), "darwin assets should NOT match Windows");
     }
 
     #[test]
@@ -634,9 +592,9 @@ mod tests {
             size: 1024,
         }];
 
-        let result = select_asset(&assets, "win", "x86_64", false, None);
+        let result = find_asset(&assets, "win", "x86_64", None);
         assert!(
-            result.is_err(),
+            matches!(result, Selection::None),
             "darwin assets should NOT match even with 'win' alias"
         );
     }
@@ -743,8 +701,11 @@ mod tests {
             size: 1024,
         }];
 
-        let result = select_asset(&assets, "win", "x86_64", false, None).unwrap();
-        assert_eq!(result.name, "app-win-x86_64.zip");
+        let result = find_asset(&assets, "win", "x86_64", None);
+        match result {
+            Selection::Exact(asset) => assert_eq!(asset.name, "app-win-x86_64.zip"),
+            _ => panic!("Expected Selection::Exact"),
+        }
     }
 
     #[test]
@@ -755,8 +716,11 @@ mod tests {
             size: 1024,
         }];
 
-        let result = select_asset(&assets, "win32", "x86_64", false, None).unwrap();
-        assert_eq!(result.name, "app-win32-x86_64.exe");
+        let result = find_asset(&assets, "win32", "x86_64", None);
+        match result {
+            Selection::Exact(asset) => assert_eq!(asset.name, "app-win32-x86_64.exe"),
+            _ => panic!("Expected Selection::Exact"),
+        }
     }
 
     #[test]
@@ -767,8 +731,11 @@ mod tests {
             size: 1024,
         }];
 
-        let result = select_asset(&assets, "win64", "x86_64", false, None).unwrap();
-        assert_eq!(result.name, "app-win64-x86_64.zip");
+        let result = find_asset(&assets, "win64", "x86_64", None);
+        match result {
+            Selection::Exact(asset) => assert_eq!(asset.name, "app-win64-x86_64.zip"),
+            _ => panic!("Expected Selection::Exact"),
+        }
     }
 
     #[test]
@@ -791,12 +758,8 @@ mod tests {
             },
         ];
 
-        // In non-terminal environment, multiple matches should error
-        let result = select_asset(&assets, "win", "x86_64", false, None);
-        assert!(
-            result.is_err(),
-            "Multiple matches should error in non-terminal environment"
-        );
+        let result = find_asset(&assets, "win", "x86_64", None);
+        assert!(matches!(result, Selection::Multiple(_)));
     }
 
     #[test]
@@ -826,38 +789,6 @@ mod tests {
     }
 
     #[test]
-    fn test_select_asset_multiple_matches_non_terminal_error() {
-        let assets = vec![
-            Asset {
-                name: "app-linux-x86_64.tar.gz".to_string(),
-                browser_download_url: "https://example.com/app1.tar.gz".to_string(),
-                size: 1024,
-            },
-            Asset {
-                name: "app-linux-amd64.zip".to_string(),
-                browser_download_url: "https://example.com/app2.zip".to_string(),
-                size: 2048,
-            },
-        ];
-
-        // In non-terminal environment (simulated by the test runner),
-        // multiple matches should return an error
-        let result = select_asset(&assets, "linux", "x86_64", false, None);
-        assert!(
-            result.is_err(),
-            "Multiple matches should error in non-terminal environment"
-        );
-
-        if let Err(e) = result {
-            let error_msg = e.to_string().to_lowercase();
-            assert!(
-                error_msg.contains("multiple") || error_msg.contains("select"),
-                "Error message should mention multiple assets and suggest --select flag"
-            );
-        }
-    }
-
-    #[test]
     fn test_select_asset_single_match_auto_selected() {
         let assets = vec![Asset {
             name: "app-linux-x86_64.tar.gz".to_string(),
@@ -865,39 +796,10 @@ mod tests {
             size: 1024,
         }];
 
-        let result = select_asset(&assets, "linux", "x86_64", false, None).unwrap();
-        assert_eq!(result.name, "app-linux-x86_64.tar.gz");
-    }
-
-    #[test]
-    fn test_select_asset_zero_matches_non_terminal_error() {
-        let assets = vec![Asset {
-            name: "app-darwin-x86_64.tar.gz".to_string(),
-            browser_download_url: "https://example.com/app.tar.gz".to_string(),
-            size: 1024,
-        }];
-
-        // In non-terminal environment, zero matches should error
-        let result = select_asset(&assets, "linux", "x86_64", false, None);
-        assert!(
-            result.is_err(),
-            "Zero matches should error in non-terminal environment"
-        );
-    }
-
-    #[test]
-    fn test_select_force_select_flag_non_terminal_error() {
-        let assets = vec![Asset {
-            name: "app-linux-x86_64.tar.gz".to_string(),
-            browser_download_url: "https://example.com/app.tar.gz".to_string(),
-            size: 1024,
-        }];
-
-        // In non-terminal environment, --select flag should error
-        let result = select_asset(&assets, "linux", "x86_64", true, None);
-        assert!(
-            result.is_err(),
-            "Force select should error in non-terminal environment"
-        );
+        let result = find_asset(&assets, "linux", "x86_64", None);
+        match result {
+            Selection::Exact(asset) => assert_eq!(asset.name, "app-linux-x86_64.tar.gz"),
+            _ => panic!("Expected Selection::Exact"),
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,8 +106,10 @@ mod tests {
 
     #[test]
     fn test_token_set_in_http_request() {
-        use std::io::{Read, Write};
-        use std::net::TcpListener;
+        use std::{
+            io::{Read, Write},
+            net::TcpListener,
+        };
 
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@ use std::env;
 use tempfile::TempDir;
 
 use crate::{
-    asset::select_asset,
+    asset::{find_asset, Selection},
     config::{configure_agent, get_auth_token},
     download::download_asset,
     extract::extract_and_save,
@@ -20,11 +20,10 @@ fn test_select_asset_from_real_repo() {
     let os = env::consts::OS;
     let arch = env::consts::ARCH;
 
-    let result = select_asset(&release.assets, os, arch, false, None);
-    // In non-terminal environment, multiple matches should error
-    match result {
-        Ok(selected) => println!("Selected asset for {}-{}: {}", os, arch, selected.name),
-        Err(e) => println!("No unique match for {}-{}: {}", os, arch, e),
+    match find_asset(&release.assets, os, arch, None) {
+        Selection::Exact(asset) => println!("Selected asset for {}-{}: {}", os, arch, asset.name),
+        Selection::Multiple(matches) => println!("{} matches for {}-{}", matches.len(), os, arch),
+        Selection::None => println!("No match for {}-{}", os, arch),
     }
 }
 
@@ -38,11 +37,11 @@ fn test_integration_download_extract_save() {
     let os = env::consts::OS;
     let arch = env::consts::ARCH;
 
-    // Skip if multiple matches (non-terminal environment)
-    let asset = match select_asset(&release.assets, os, arch, false, None) {
-        Ok(a) => a,
-        Err(_) => {
-            println!("Skipping test: multiple assets found for {}-{}", os, arch);
+    // Skip if multiple or no matches
+    let asset = match find_asset(&release.assets, os, arch, None) {
+        Selection::Exact(a) => a,
+        _ => {
+            println!("Skipping test: no unique match for {}-{}", os, arch);
             return;
         }
     };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@ use std::env;
 use tempfile::TempDir;
 
 use crate::{
-    asset::{find_asset, Selection},
+    asset::{Selection, find_asset},
     config::{configure_agent, get_auth_token},
     download::download_asset,
     extract::extract_and_save,


### PR DESCRIPTION
This pull request refactors the asset selection logic to improve clarity and testability by separating the process of finding matching assets from interactive selection. It introduces a new `Selection` enum to represent the result of asset matching, updates the tests accordingly, and improves documentation for the version cache mechanism.

### Asset selection logic refactor

* Introduced a new `Selection` enum (`Exact`, `Multiple`, `None`) and a `find_asset` function to return all possible asset matches without performing interactive selection. The interactive selection and error handling are now only performed in `select_asset`. This makes the codebase cleaner and easier to test. [[1]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L190-R196) [[2]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L211-R262)
* Refactored tests in `src/asset.rs` to use `find_asset` and check for the correct `Selection` variant instead of relying on error returns from `select_asset`. This improves test clarity and reliability. [[1]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L436-R408) [[2]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L448-R420) [[3]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L547-R522) [[4]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L571-R546) [[5]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L594-R565) [[6]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L625-R584) [[7]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L637-R597) [[8]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L746-R708) [[9]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L758-R723) [[10]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L770-R738) [[11]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L794-R762) [[12]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L828-L859) [[13]](diffhunk://#diff-b0a36a98aba28c57fbacbf56572175787cad96d4090baaf905135d07bede3673L868-L901)

### Test improvements

* Updated integration tests in `src/tests.rs` to use the new `find_asset` and `Selection` enum, improving clarity and making them robust to cases with multiple or no matches. [[1]](diffhunk://#diff-a0262fea108af44a98cc49e5eb72641963dd816513f2d0a22eb738fcfed55ebeL6-R6) [[2]](diffhunk://#diff-a0262fea108af44a98cc49e5eb72641963dd816513f2d0a22eb738fcfed55ebeL23-R26) [[3]](diffhunk://#diff-a0262fea108af44a98cc49e5eb72641963dd816513f2d0a22eb738fcfed55ebeL41-R44)
* Improved the HTTP token test in `src/config.rs` by replacing the dependency on an external service with a local TCP server, making the test more reliable and self-contained.

### Documentation

* Added a new section to `README.md` documenting the version cache mechanism, including cache behavior, bypass options, and file format.