### PR TITLE
feat(asset): Infer default arch from OS when asset name lacks arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ target
 /target
 .env
 .codegraph
+.pi/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,65 @@
+# Domain Glossary
+
+## Platform
+
+A combination of **Operating System** and **Architecture** that identifies a target environment.
+
+### Operating System (OS)
+The target OS for a binary asset. Supported values:
+
+| Canonical | Aliases |
+|-----------|---------|
+| `linux`   | — |
+| `macos`   | — |
+| `windows` | `win`, `win32`, `win64` |
+
+### Architecture (Arch)
+The target CPU architecture for a binary asset. Supported values:
+
+| Canonical | Aliases |
+|-----------|---------|
+| `x86_64`  | `amd64`, `x64` |
+| `aarch64` | `arm64` |
+
+### Default Architecture
+When an asset filename contains an OS indicator but **no explicit architecture**, `grd` assumes one:
+
+| OS      | Default Arch | Rationale |
+|---------|-------------|-----------|
+| linux   | `x86_64`    | Dominant in server/desktop Linux |
+| macos   | `aarch64`   | Apple Silicon is now default for macOS releases |
+| windows | `x86_64`    | Dominant in Windows ecosystems |
+
+This avoids false negatives for projects that omit the arch from asset names (common when only one arch is shipped).
+
+An asset that **does** contain an explicit arch pattern (e.g. `x86_64`, `aarch64`, `arm64`, `i386`, `armv7`) is always matched against its stated arch; the default-arch fallback only applies when no arch pattern is detected.
+
+### Known Architecture Patterns
+Release filenames commonly embed any of these substrings, which `has_explicit_arch_pattern` recognizes so that the default-arch fallback does not falsely match assets built for other architectures:
+
+- `x86_64`, `amd64`, `x64`, `aarch64`, `arm64`
+- `i686`, `i386`, `x86` (32-bit x86)
+- `armhf`, `armv7` (32-bit ARM)
+- `riscv64`, `riscv32` (RISC-V)
+- `ppc64le`, `ppc64`, `powerpc` (PowerPC)
+- `s390x` (IBM Z)
+- `mips64`, `mips` (MIPS)
+- `win64`, `win32` (Windows-platform-derived)
+
+## Asset
+A downloadable file in a GitHub Release. Each asset has:
+- `name` – filename (e.g. `app-linux-x86_64.tar.gz`)
+- `browser_download_url` – download URL
+- `size` – bytes
+
+## Selection
+The result of matching assets against a target OS + arch:
+
+| Variant    | Meaning |
+|------------|---------|
+| `Exact`    | Exactly one match |
+| `Multiple` | More than one match; user must select |
+| `None`     | No match found |
+
+## Version Cache
+Persistent state at `~/.grd/state.toml` keyed by `"owner/repo"`, recording the last-downloaded version to skip re-downloads.

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -93,6 +93,38 @@ fn format_size(bytes: u64) -> String {
     }
 }
 
+fn has_explicit_arch_pattern(name: &str) -> bool {
+    let name = name.to_lowercase();
+    name.contains("x86_64")
+        || name.contains("amd64")
+        || name.contains("x64")
+        || name.contains("aarch64")
+        || name.contains("arm64")
+        || name.contains("i686")
+        || name.contains("i386")
+        || name.contains("armhf")
+        || name.contains("armv7")
+        || name.contains("riscv64")
+        || name.contains("riscv32")
+        || name.contains("ppc64le")
+        || name.contains("ppc64")
+        || name.contains("powerpc")
+        || name.contains("s390x")
+        || name.contains("mips")
+        || name.contains("win64")
+        || name.contains("win32")
+        || name.contains("x86")
+}
+
+fn default_arch_for_os(os: &str) -> Option<&'static str> {
+    match os {
+        "linux" => Some("x86_64"),
+        "macos" => Some("aarch64"),
+        "windows" => Some("x86_64"),
+        _ => None,
+    }
+}
+
 fn calculate_match_score(asset_name: &str, target_os: &str, target_arch: &str) -> i32 {
     let name = asset_name.to_lowercase();
     let mut score = 0;
@@ -366,8 +398,15 @@ fn collect_matches<'a>(
                         || name.contains("x64")
                         || (normalized_os == "windows" && name.contains("win64"))
                         || (normalized_os == "windows" && name.contains("win32"))
+                        || (!has_explicit_arch_pattern(&name)
+                            && default_arch_for_os(normalized_os) == Some("x86_64"))
                 }
-                Some("aarch64") => name.contains("aarch64") || name.contains("arm64"),
+                Some("aarch64") => {
+                    name.contains("aarch64")
+                        || name.contains("arm64")
+                        || (!has_explicit_arch_pattern(&name)
+                            && default_arch_for_os(normalized_os) == Some("aarch64"))
+                }
                 _ => false,
             };
             os_match && arch_match && !blacklist.iter().any(|b| name.contains(b))
@@ -917,5 +956,186 @@ mod tests {
     fn test_normalize_os_win64() {
         let result = normalize_os("win64").unwrap();
         assert_eq!(result, "windows");
+    }
+    #[test]
+    fn test_default_arch_for_os_values() {
+        assert_eq!(default_arch_for_os("linux"), Some("x86_64"));
+        assert_eq!(default_arch_for_os("macos"), Some("aarch64"));
+        assert_eq!(default_arch_for_os("windows"), Some("x86_64"));
+        assert_eq!(default_arch_for_os("freebsd"), None);
+        assert_eq!(default_arch_for_os(""), None);
+    }
+
+    #[test]
+    fn test_has_explicit_arch_pattern_supported() {
+        assert!(has_explicit_arch_pattern("app-linux-x86_64.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-amd64.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-aarch64.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-arm64.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-win64.zip"));
+        assert!(has_explicit_arch_pattern("app-win32.zip"));
+        assert!(has_explicit_arch_pattern("app.linux.x64.tar.gz"));
+    }
+
+    #[test]
+    fn test_has_explicit_arch_pattern_unsupported() {
+        assert!(has_explicit_arch_pattern("app-linux-i386.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-i686.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-armhf.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-armv7.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-riscv64.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-ppc64le.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-s390x.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-mips.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux-powerpc.tar.gz"));
+    }
+
+    #[test]
+    fn test_has_explicit_arch_pattern_x86_32() {
+        assert!(has_explicit_arch_pattern("app-linux-x86.tar.gz"));
+        assert!(has_explicit_arch_pattern("app-linux.i386.rpm"));
+    }
+
+    #[test]
+    fn test_has_explicit_arch_pattern_no_arch() {
+        assert!(!has_explicit_arch_pattern("app-linux.tar.gz"));
+        assert!(!has_explicit_arch_pattern("app-macos.zip"));
+        assert!(!has_explicit_arch_pattern("app-win.zip"));
+        assert!(!has_explicit_arch_pattern("app.zip"));
+        assert!(!has_explicit_arch_pattern("app-linux-musl.tar.gz"));
+    }
+
+    #[test]
+    fn test_select_asset_no_arch_assumes_x86_64_linux() {
+        let assets = vec![Asset {
+            name: "app-linux.tar.gz".to_string(),
+            browser_download_url: "https://example.com/app.tar.gz".to_string(),
+            size: 1024,
+        }];
+        let result = find_asset(&assets, "linux", "x86_64", None);
+        match result {
+            Selection::Exact(asset) => assert_eq!(asset.name, "app-linux.tar.gz"),
+            _ => panic!("Expected Selection::Exact"),
+        }
+    }
+
+    #[test]
+    fn test_select_asset_no_arch_does_not_match_aarch64_linux() {
+        let assets = vec![Asset {
+            name: "app-linux.tar.gz".to_string(),
+            browser_download_url: "https://example.com/app.tar.gz".to_string(),
+            size: 1024,
+        }];
+        let result = find_asset(&assets, "linux", "aarch64", None);
+        assert!(matches!(result, Selection::None));
+    }
+
+    #[test]
+    fn test_select_asset_no_arch_assumes_aarch64_macos() {
+        let assets = vec![Asset {
+            name: "app-macos.tar.gz".to_string(),
+            browser_download_url: "https://example.com/app.tar.gz".to_string(),
+            size: 1024,
+        }];
+        let result = find_asset(&assets, "macos", "aarch64", None);
+        match result {
+            Selection::Exact(asset) => assert_eq!(asset.name, "app-macos.tar.gz"),
+            _ => panic!("Expected Selection::Exact"),
+        }
+    }
+
+    #[test]
+    fn test_select_asset_no_arch_does_not_match_x86_64_macos() {
+        let assets = vec![Asset {
+            name: "app-macos.tar.gz".to_string(),
+            browser_download_url: "https://example.com/app.tar.gz".to_string(),
+            size: 1024,
+        }];
+        let result = find_asset(&assets, "macos", "x86_64", None);
+        assert!(
+            matches!(result, Selection::None),
+            "macos default is aarch64, not x86_64"
+        );
+    }
+
+    #[test]
+    fn test_select_asset_no_arch_assumes_x86_64_windows() {
+        let assets = vec![Asset {
+            name: "app-win.zip".to_string(),
+            browser_download_url: "https://example.com/app.zip".to_string(),
+            size: 1024,
+        }];
+        let result = find_asset(&assets, "windows", "x86_64", None);
+        match result {
+            Selection::Exact(asset) => assert_eq!(asset.name, "app-win.zip"),
+            _ => panic!("Expected Selection::Exact"),
+        }
+    }
+
+    #[test]
+    fn test_select_asset_explicit_arch_preferred_over_implicit() {
+        let assets = vec![
+            Asset {
+                name: "app-linux-x86_64.tar.gz".to_string(),
+                browser_download_url: "https://example.com/app-x86_64.tar.gz".to_string(),
+                size: 2048,
+            },
+            Asset {
+                name: "app-linux.tar.gz".to_string(),
+                browser_download_url: "https://example.com/app-noarch.tar.gz".to_string(),
+                size: 1024,
+            },
+        ];
+        let result = find_asset(&assets, "linux", "x86_64", None);
+        match result {
+            Selection::Multiple(mut matches) => {
+                let mut refs: Vec<&Asset> = matches.iter().collect();
+                sort_by_score(&mut refs, "linux", "x86_64");
+                assert_eq!(refs[0].name, "app-linux-x86_64.tar.gz");
+            }
+            _ => panic!("Expected Selection::Multiple"),
+        }
+    }
+
+    #[test]
+    fn test_select_asset_no_arch_i386_not_matched_as_x86_64() {
+        let assets = vec![Asset {
+            name: "app-linux-i386.tar.gz".to_string(),
+            browser_download_url: "https://example.com/app-i386.tar.gz".to_string(),
+            size: 1024,
+        }];
+        let result = find_asset(&assets, "linux", "x86_64", None);
+        assert!(
+            matches!(result, Selection::None),
+            "i386 has explicit arch, should NOT match x86_64"
+        );
+    }
+
+    #[test]
+    fn test_select_asset_no_arch_win32_alias_matches() {
+        let assets = vec![Asset {
+            name: "app-win.zip".to_string(),
+            browser_download_url: "https://example.com/app-zip.zip".to_string(),
+            size: 1024,
+        }];
+        let result = find_asset(&assets, "win32", "x86_64", None);
+        match result {
+            Selection::Exact(asset) => assert_eq!(asset.name, "app-win.zip"),
+            _ => panic!("Expected Selection::Exact"),
+        }
+    }
+
+    #[test]
+    fn test_select_asset_no_arch_darwin_exclusion_still_applies() {
+        let assets = vec![Asset {
+            name: "app-darwin.tar.gz".to_string(),
+            browser_download_url: "https://example.com/app.tar.gz".to_string(),
+            size: 1024,
+        }];
+        let result = find_asset(&assets, "windows", "x86_64", None);
+        assert!(
+            matches!(result, Selection::None),
+            "darwin asset should not match windows"
+        );
     }
 }


### PR DESCRIPTION
Asset filenames without an explicit architecture indicator (e.g. app-linux.tar.gz) now match against a default arch per OS:
- linux -> x86_64
- macos -> aarch64
- windows -> x86_64

Previously such assets would never match any target arch, causing false negatives for projects that omit arch from filenames.

A new has_explicit_arch_pattern() guard prevents false matches for assets with other known arch substrings (i386, armv7, etc.).