### PR TITLE
feat(asset): Improve asset selection with arch-specific preference and loong64 support

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,7 @@ The target CPU architecture for a binary asset. Supported values:
 |-----------|---------|
 | `x86_64`  | `amd64`, `x64` |
 | `aarch64` | `arm64` |
+| `loong64` | `loongarch64` |
 
 ### Default Architecture
 When an asset filename contains an OS indicator but **no explicit architecture**, `grd` assumes one:
@@ -32,12 +33,12 @@ When an asset filename contains an OS indicator but **no explicit architecture**
 
 This avoids false negatives for projects that omit the arch from asset names (common when only one arch is shipped).
 
-An asset that **does** contain an explicit arch pattern (e.g. `x86_64`, `aarch64`, `arm64`, `i386`, `armv7`) is always matched against its stated arch; the default-arch fallback only applies when no arch pattern is detected.
+An asset that **does** contain an explicit arch pattern (e.g. `x86_64`, `aarch64`, `arm64`, `loong64`, `i386`, `armv7`) is always matched against its stated arch; the default-arch fallback only applies when no arch pattern is detected.
 
 ### Known Architecture Patterns
 Release filenames commonly embed any of these substrings, which `has_explicit_arch_pattern` recognizes so that the default-arch fallback does not falsely match assets built for other architectures:
 
-- `x86_64`, `amd64`, `x64`, `aarch64`, `arm64`
+- `x86_64`, `amd64`, `x64`, `aarch64`, `arm64`, `loong64`, `loongarch64`
 - `i686`, `i386`, `x86` (32-bit x86)
 - `armhf`, `armv7` (32-bit ARM)
 - `riscv64`, `riscv32` (RISC-V)

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ repository in `~/.grd/state.toml`:
 - `--force`: Skip the version cache check and force a fresh download.
 - `-y / --yes`: Skip the upgrade confirmation prompt.
 - `--os`: Target OS (windows, macos, linux). Defaults to auto-detection.
-- `--arch`: Target architecture (x86_64, aarch64, amd64, x64, arm64). Defaults to auto-detection. Aliases: amd64 and x64 → x86_64; arm64 → aarch64.
+- `--arch`: Target architecture (x86_64, aarch64, loong64, amd64, x64, arm64, loongarch64). Defaults to auto-detection. Aliases: amd64 and x64 → x86_64; arm64 → aarch64; loongarch64 → loong64.
 
 ## Building
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -3,7 +3,7 @@ use std::{
     io::{self, IsTerminal, Write},
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 
 use crate::github::Asset;
 
@@ -246,6 +246,43 @@ fn sort_by_score(assets: &mut Vec<&Asset>, target_os: &str, target_arch: &str) {
     });
 }
 
+fn best_unique_match<'a>(
+    assets: &[&'a Asset],
+    target_os: &str,
+    target_arch: &str,
+) -> Option<&'a Asset> {
+    let mut best: Option<(&'a Asset, i32)> = None;
+    let mut best_count = 0;
+
+    for asset in assets {
+        let score = calculate_match_score(&asset.name, target_os, target_arch);
+        match best {
+            None => {
+                best = Some((asset, score));
+                best_count = 1;
+            }
+            Some((_, best_score)) if score > best_score => {
+                best = Some((asset, score));
+                best_count = 1;
+            }
+            Some((_, best_score)) if score == best_score => {
+                best_count += 1;
+            }
+            _ => {}
+        }
+    }
+
+    if best_count == 1 {
+        best.map(|(asset, _)| asset)
+    } else {
+        None
+    }
+}
+
+fn canonical_arch_for_matching(arch: &str) -> String {
+    normalize_arch(arch).unwrap_or_else(|_| arch.to_lowercase())
+}
+
 fn show_all_assets(assets: &[&Asset], target_os: &str, target_arch: &str) {
     for (i, asset) in assets.iter().enumerate() {
         let score = calculate_match_score(&asset.name, target_os, target_arch);
@@ -296,11 +333,12 @@ pub fn find_asset(
     });
 
     let (normalized_os, inferred_arch) = normalize_platform_identifier(os);
+    let normalized_arch = canonical_arch_for_matching(arch);
 
     let effective_arch = if inferred_arch.is_some() {
         inferred_arch
     } else {
-        Some(arch.to_string())
+        Some(normalized_arch)
     };
 
     let matches = collect_matches(
@@ -310,6 +348,14 @@ pub fn find_asset(
         &effective_arch,
         no_ext_filter,
     );
+
+    if let Some(asset) = best_unique_match(
+        &matches,
+        &normalized_os,
+        effective_arch.as_deref().unwrap_or(arch),
+    ) {
+        return Selection::Exact(asset.clone());
+    }
 
     if matches.len() > 1
         && normalized_os == "windows"
@@ -344,7 +390,8 @@ pub fn select_asset(
         s.split(',').map(|w| w.trim().to_lowercase()).collect()
     });
     let (normalized_os, inferred_arch) = normalize_platform_identifier(os);
-    let effective_arch = inferred_arch.or(Some(arch.to_string()));
+    let normalized_arch = canonical_arch_for_matching(arch);
+    let effective_arch = inferred_arch.or(Some(normalized_arch));
 
     if force_select {
         if !io::stdin().is_terminal() {
@@ -726,6 +773,78 @@ mod tests {
 
         let result = find_asset(&assets, "linux", "x86_64", None, false);
         assert!(matches!(result, Selection::Multiple(_)));
+    }
+
+    #[test]
+    fn test_select_asset_prefers_linux_amd64_over_linux() {
+        let assets = vec![
+            Asset {
+                name: "golangci-lint-2.12.2-linux.tar.gz".to_string(),
+                browser_download_url: "https://example.com/linux.tar.gz".to_string(),
+                size: 1024,
+            },
+            Asset {
+                name: "golangci-lint-2.12.2-linux-amd64.tar.gz".to_string(),
+                browser_download_url: "https://example.com/linux-amd64.tar.gz".to_string(),
+                size: 2048,
+            },
+        ];
+
+        let result = find_asset(&assets, "linux", "amd64", None, false);
+        match result {
+            Selection::Exact(asset) => {
+                assert_eq!(asset.name, "golangci-lint-2.12.2-linux-amd64.tar.gz")
+            }
+            _ => panic!("Expected Selection::Exact"),
+        }
+    }
+
+    #[test]
+    fn test_select_asset_prefers_windows_amd64_over_windows() {
+        let assets = vec![
+            Asset {
+                name: "golangci-lint-2.12.2-windows.zip".to_string(),
+                browser_download_url: "https://example.com/windows.zip".to_string(),
+                size: 1024,
+            },
+            Asset {
+                name: "golangci-lint-2.12.2-windows-amd64.zip".to_string(),
+                browser_download_url: "https://example.com/windows-amd64.zip".to_string(),
+                size: 2048,
+            },
+        ];
+
+        let result = find_asset(&assets, "windows", "amd64", None, false);
+        match result {
+            Selection::Exact(asset) => {
+                assert_eq!(asset.name, "golangci-lint-2.12.2-windows-amd64.zip")
+            }
+            _ => panic!("Expected Selection::Exact"),
+        }
+    }
+
+    #[test]
+    fn test_select_asset_prefers_win64_over_windows() {
+        let assets = vec![
+            Asset {
+                name: "golangci-lint-2.12.2-windows.zip".to_string(),
+                browser_download_url: "https://example.com/windows.zip".to_string(),
+                size: 1024,
+            },
+            Asset {
+                name: "golangci-lint-2.12.2-win64.zip".to_string(),
+                browser_download_url: "https://example.com/win64.zip".to_string(),
+                size: 2048,
+            },
+        ];
+
+        let result = find_asset(&assets, "win64", "amd64", None, false);
+        match result {
+            Selection::Exact(asset) => {
+                assert_eq!(asset.name, "golangci-lint-2.12.2-win64.zip")
+            }
+            _ => panic!("Expected Selection::Exact"),
+        }
     }
 
     #[test]
@@ -1166,12 +1285,8 @@ mod tests {
         ];
         let result = find_asset(&assets, "linux", "x86_64", None, false);
         match result {
-            Selection::Multiple(mut matches) => {
-                let mut refs: Vec<&Asset> = matches.iter().collect();
-                sort_by_score(&mut refs, "linux", "x86_64");
-                assert_eq!(refs[0].name, "app-linux-x86_64.tar.gz");
-            }
-            _ => panic!("Expected Selection::Multiple"),
+            Selection::Exact(asset) => assert_eq!(asset.name, "app-linux-x86_64.tar.gz"),
+            _ => panic!("Expected Selection::Exact"),
         }
     }
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -3,7 +3,7 @@ use std::{
     io::{self, IsTerminal, Write},
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::github::Asset;
 
@@ -76,8 +76,9 @@ pub fn normalize_arch(input: &str) -> Result<String> {
     match normalized.as_str() {
         "x86_64" | "amd64" | "x64" => Ok("x86_64".to_string()),
         "aarch64" | "arm64" => Ok("aarch64".to_string()),
+        "loong64" | "loongarch64" => Ok("loong64".to_string()),
         _ => bail!(
-            "Invalid architecture '{}'. Supported: x86_64 (aliases: amd64, x64), aarch64 (alias: arm64)",
+            "Invalid architecture '{}'. Supported: x86_64 (aliases: amd64, x64), aarch64 (alias: arm64), loong64 (alias: loongarch64)",
             input
         ),
     }
@@ -100,6 +101,8 @@ fn has_explicit_arch_pattern(name: &str) -> bool {
         || name.contains("x64")
         || name.contains("aarch64")
         || name.contains("arm64")
+        || name.contains("loong64")
+        || name.contains("loongarch64")
         || name.contains("i686")
         || name.contains("i386")
         || name.contains("armhf")
@@ -195,6 +198,7 @@ fn calculate_match_score(asset_name: &str, target_os: &str, target_arch: &str) -
     let arch_patterns = match target_arch {
         "x86_64" => vec!["x86_64", "amd64", "x64", "win64"],
         "aarch64" => vec!["aarch64", "arm64"],
+        "loong64" => vec!["loong64", "loongarch64"],
         _ => vec![],
     };
 
@@ -532,6 +536,12 @@ fn collect_matches<'a>(
                         || (!has_explicit_arch_pattern(&name)
                             && default_arch_for_os(normalized_os) == Some("aarch64"))
                 }
+                Some("loong64") => {
+                    name.contains("loong64")
+                        || name.contains("loongarch64")
+                        || (!has_explicit_arch_pattern(&name)
+                            && default_arch_for_os(normalized_os) == Some("loong64"))
+                }
                 _ => false,
             };
             ext_ok && os_match && arch_match && !blacklist.iter().any(|b| name.contains(b))
@@ -570,6 +580,8 @@ mod tests {
         assert_eq!(normalize_arch("aarch64").unwrap(), "aarch64");
         assert_eq!(normalize_arch("arm64").unwrap(), "aarch64");
         assert_eq!(normalize_arch("ARM64").unwrap(), "aarch64");
+        assert_eq!(normalize_arch("loong64").unwrap(), "loong64");
+        assert_eq!(normalize_arch("loongarch64").unwrap(), "loong64");
     }
 
     #[test]
@@ -628,6 +640,33 @@ mod tests {
             matches!(result, Selection::None),
             "darwin assets should NOT match win64"
         );
+    }
+
+    #[test]
+    fn test_select_asset_loong64_not_matched_to_x86_64() {
+        let assets = vec![Asset {
+            name: "app-linux-loong64.tar.gz".to_string(),
+            browser_download_url: "https://example.com/app.tar.gz".to_string(),
+            size: 1024,
+        }];
+
+        let result = find_asset(&assets, "linux", "x86_64", None, false);
+        assert!(
+            matches!(result, Selection::None),
+            "loong64 assets should NOT match x86_64"
+        );
+    }
+
+    #[test]
+    fn test_select_asset_loong64_matches_loong64() {
+        let assets = vec![Asset {
+            name: "app-linux-loong64.tar.gz".to_string(),
+            browser_download_url: "https://example.com/app.tar.gz".to_string(),
+            size: 1024,
+        }];
+
+        let result = find_asset(&assets, "linux", "loong64", None, false);
+        assert!(matches!(result, Selection::Exact(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two improvements to release asset selection:

### Prefer arch-specific assets over generic ones
When multiple assets match (e.g.  and ), automatically pick the one with an explicit architecture matching the target. This avoids prompting the user when the correct asset is unambiguous.

- Adds  that returns an exact selection when exactly one asset has the highest match score
- Previously, these cases fell through to  and required manual picking

### Add loong64 architecture support
-  /  normalizes to  canonical form
- Explicit arch pattern detection includes  /  substrings
- No longer falls back to x86_64 default on loong64-only asset lists

## Changes
-  — Core logic + 5 new tests
-  /  — Document loong64 support

## Test plan
- [x] All existing tests pass
- [x] New tests: loong64 not matched to x86_64, loong64 matches loong64
- [x] New tests: prefer linux-amd64 over linux, prefer windows-amd64 over windows, prefer win64 over windows