### PR TITLE
feat(cli): add --dry-run mode to simulate installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ target
 .env
 .codegraph
 .pi/
+.todos/

--- a/.plan/dry-run-mode.md
+++ b/.plan/dry-run-mode.md
@@ -1,0 +1,29 @@
+# Plan: `--dry-run` mode for grd
+
+## Goal
+`grd owner/repo --dry-run` resolves release + asset and prints what would happen, without downloading, extracting, writing state, or creating dirs.
+
+## Background
+Main flow in `src/main.rs` (lines ~105-242): resolve dest → `create_dir_all` → GitHub API fetch release → normalize os/arch → select asset → bin_name → force/upgrade check → `download_asset` → `extract_and_save` → `state.set_cached`+`save`. Flag lives in `src/cli.rs` `Args`.
+
+## Approach
+1. **`src/cli.rs`**: add `#[arg(long)] pub dry_run: bool` to `Args`. Doc: "Simulate installation without downloading". No alias, no conflicts. Add parse test (`--dry-run` true, default false).
+2. **`src/main.rs`**: after `println!("Selected asset: {}", asset.name)` and bin_name resolution, insert:
+   - `if args.dry_run { ... report ...; return Ok(()) }`
+3. **Report content**:
+   - `[dry-run] would install '{bin_name}' to {dest}`
+   - `[dry-run] source: {repo} {release.tag_name} → {asset.name}`
+   - already-installed detection: if `!args.force` and target exists + same version cached → `[dry-run] already at {asset.name} {tag}; no action` instead of would-install. (Reuse existing logic shape; dry-run never prompts, never returns non-zero.)
+4. **Short-circuit placement**: before force/upgrade prompt AND before `create_dir_all` (line 112). Gate `create_dir_all` with `!args.dry_run`. `--force` ignored in dry-run (report "would re-download" via same would-install line).
+5. **Tests**: unit test for flag parse in cli.rs; check `src/tests.rs` patterns for main-path coverage (likely flag-parse test only — no network in tests).
+
+## Trade-offs
+- **Gate `create_dir_all` vs leave it**: leaving it = dry-run creates dest dir = side effect, violates "no actual changes". Gated.
+- **Early exit before force/prompt block**: keeps dry-run non-interactive, never blocks on stdin, never returns error for upgrade-prompt path. Matches "dry-run wins".
+- **Keep API calls**: user confirmed — dry-run still resolves real asset, output trustworthy.
+
+## Open questions
+- None blocking. (Exact test strategy for main path pending `src/tests.rs` inspection.)
+
+## Next step
+Implement: edit `src/cli.rs` (flag + tests), edit `src/main.rs` (gate + report), run `cargo check -q`, `cargo test -q`, clippy.

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ repository in `~/.grd/state.toml`:
 - `--no-ext-filter`: Disable the default extension allowlist (see Extension Filter below)
 - `--memory-limit`: Memory limit in bytes; downloads larger than this use temp files (default: 104857600, i.e., 100MB)
 - `--force`: Skip the version cache check and force a fresh download.
+- `--dry-run`: Simulate installation without downloading. Resolves the release and asset, reports what would happen (e.g., `[dry-run] would install 'grd' to /usr/local/bin`), and exits without downloading, extracting, creating directories, or writing state. Never prompts; ignores `--force`.
+
 - `-y / --yes`: Skip the upgrade confirmation prompt.
 - `--os`: Target OS (windows, macos, linux). Defaults to auto-detection.
 - `--arch`: Target architecture (x86_64, aarch64, loong64, amd64, x64, arm64, loongarch64). Defaults to auto-detection. Aliases: amd64 and x64 → x86_64; arm64 → aarch64; loongarch64 → loong64.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,10 @@ pub struct Args {
     #[arg(long)]
     pub force: bool,
 
+    #[arg(long)]
+    /// Simulate installation without downloading
+    pub dry_run: bool,
+
     #[arg(short = 'y', long)]
     pub yes: bool,
 
@@ -108,6 +112,18 @@ mod tests {
     fn test_force_flag_parses_as_true() {
         let args = Args::parse_from(["grd", "owner/repo", "--force"]);
         assert!(args.force);
+    }
+
+    #[test]
+    fn test_dry_run_flag_defaults_to_false() {
+        let args = Args::parse_from(["grd", "owner/repo"]);
+        assert!(!args.dry_run);
+    }
+
+    #[test]
+    fn test_dry_run_flag_parses_as_true() {
+        let args = Args::parse_from(["grd", "owner/repo", "--dry-run"]);
+        assert!(args.dry_run);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,9 @@ fn main() -> Result<()> {
             .map(PathBuf::from)
             .unwrap_or_else(state::State::default_install_path),
     };
-    fs::create_dir_all(&dest).context("Failed to create destination directory")?;
+    if !args.dry_run {
+        fs::create_dir_all(&dest).context("Failed to create destination directory")?;
+    }
 
     let ua = format!("lucidfrontier45/grd-{}", env!("CARGO_PKG_VERSION"));
     let token = config::get_auth_token();
@@ -187,6 +189,38 @@ fn main() -> Result<()> {
         .bin_name
         .clone()
         .unwrap_or_else(|| repo.split('/').next_back().unwrap_or("app").to_string());
+
+    if args.dry_run {
+        let target_path = if args.no_decompress {
+            dest.join(&asset.name)
+        } else if cfg!(windows) {
+            dest.join(format!("{}.exe", bin_name))
+        } else {
+            dest.join(&bin_name)
+        };
+        let cache = state::State::load();
+        let cached = cache.get_cached(repo);
+        let is_same_version =
+            cached.is_some_and(|c| c.tag == release.tag_name && c.asset == asset.name);
+
+        if !args.force && target_path.exists() && is_same_version {
+            println!(
+                "[dry-run] already at {} {}; no action",
+                asset.name, release.tag_name
+            );
+            return Ok(());
+        }
+        println!(
+            "[dry-run] would install '{}' to {}",
+            bin_name,
+            dest.display()
+        );
+        println!(
+            "[dry-run] source: {} {} → {}",
+            repo, release.tag_name, asset.name
+        );
+        return Ok(());
+    }
 
     if !args.force {
         let target_path = if args.no_decompress {


### PR DESCRIPTION
## Summary

Adds `grd owner/repo --dry-run`: resolves the release + asset via the GitHub API, then reports what would happen — without downloading, extracting, creating dirs, or writing state.

## Behavior

- `[dry-run] would install '{bin}' to {dest}` + `[dry-run] source: {repo} {tag} → {asset}`
- Already-installed detection (reuse existing logic shape): if `--force` not set and target exists + same version cached → `[dry-run] already at {asset} {tag}; no action`
- Short-circuits before force/upgrade prompt and before `create_dir_all` (gated with `!args.dry_run`)
- Never prompts on stdin, never returns non-zero
- `--force` ignored — reports would-install instead of already-at

## Tests

- cli.rs parse tests: `--dry-run` default false / parses true
- 158 tests pass; clippy `-D warnings` clean